### PR TITLE
main.jade: Drop redundant attributes

### DIFF
--- a/main.jade
+++ b/main.jade
@@ -8,10 +8,10 @@ html
         meta(name="viewport", content="user-scalable=no, initial-scale=1, maximum-scale=1, width=device-width, height=device-width, target-densitydpi=device-dpi")
 
         title #{version}::#{component}
-        link(rel="stylesheet", type="text/css", href="#{css}")
-        script(type="text/javascript", src="http://code.jquery.com/jquery-1.10.2.min.js")
+        link(rel="stylesheet", href="#{css}")
+        script(src="http://code.jquery.com/jquery-1.10.2.min.js")
         if javascript
-            script(type="text/javascript", src = "#{javascript}")
+            script(src="#{javascript}")
 
     body
         -while (repeats > 0)


### PR DESCRIPTION
Always been redundant in "real" browsers (going back to Netscape and IE4 at least),
and finally in the spec per HTML5.
